### PR TITLE
Cumulative changes to implement paging.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,8 @@ module.exports = function(grunt) {
     'js/lib/paper-full.min.js',
     'js/lib/spectrum.js',
     'js/lib/jquery.awesome-cursor.js',
-    'js/lib/i18next.min.js'
+    'js/lib/i18next.min.js',
+    'bower_components/simplePagination.js/jquery.simplePagination.js'
   ],
 
   // libraries/plugins for running tests
@@ -100,7 +101,8 @@ module.exports = function(grunt) {
         'css/spectrum.css',
         'css/mirador.css',
         'css/material-icons.css',
-        '!css/mirador-combined.css'
+        '!css/mirador-combined.css',
+        'bower_components/simplePagination.js/simplePagination.css'
         ],
         dest: 'build/mirador/css/mirador-combined.css'
       }
@@ -406,7 +408,7 @@ module.exports = function(grunt) {
   // Runs instanbul coverage
   //grunt.registerTask('cover', 'karma:cover');
   grunt.registerTask('cover', []);
-  
+
   // ----------
   // Runs this on travis.
   grunt.registerTask('ci', [

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "paper": "git://github.com/paperjs/paper.js.git#*",
     "spectrum": "git://github.com/bgrins/spectrum.git#*",
     "jquery-awesome-cursor": "git://github.com/jwarby/jquery-awesome-cursor.git#*",
-    "qTip2": "~2.2.1"
+    "qTip2": "~2.2.1",
+    "simplePagination.js": "*"
   },
   "devDependencies": {
     "sinon-server": "http://sinonjs.org/releases/sinon-server-1.12.2.js",

--- a/js/src/widgets/searchTab.js
+++ b/js/src/widgets/searchTab.js
@@ -92,20 +92,24 @@
 
       this.element.find(".js-perform-query").on('submit', function(event){
         event.preventDefault();
+
         var query = _this.element.find(".js-query").val();
         var motivation = _this.element.find(".js-motivation").val();
         var date = _this.element.find(".js-date").val();
         var user = _this.element.find(".js-user").val();
-        var box = _this.element.find(".js-box").val();
-        var query_params = {q: query, motivation: motivation, date: date, user: user, box: box};
-        _this.displaySearchWithin(query_params);
+
+        _this.displaySearchWithin({
+          "q": query,
+          "motivation": motivation,
+          "date": date,
+          "user": user
         });
+      });
 
       this.element.find(".js-search-expand").on('click', function(event){
         event.preventDefault();
 
-        _this.element.find(".js-search-expanded").slideToggle("slow", function(){
-        });
+        _this.element.find(".js-search-expanded").slideToggle("fast");
 
         if (jQuery(this).text() === "more"){
           jQuery(this).html("less");
@@ -152,10 +156,10 @@
 
           '<a class="js-search-expand" style="display: block; margin: 0 0 5px 0">more</a>',
           '<div class="js-search-expanded" style="display: none;">',
-            '<input class="js-motivation" type="text" placeholder="painting"/>',
+            '<input class="js-motivation" type="text" placeholder="motivation"/>',
             '<input class="js-date" type="text" placeholder="date"/>',
             '<input class="js-user" type="text" placeholder="user"/>',
-            '<input class="js-box" type="text" placeholder="box"/>',
+            // '<input class="js-box" type="text" placeholder="box: x, y, w, h"/>',
           '</div>',
         '</form>',
         '<div class="search-results-list"></div>',


### PR DESCRIPTION
Had to extract changes in order to exclude some changes from Master that I had merged.

One thing of note: this paging should not effect the search results display UNLESS paging is present in the search results. Currently, your search service does not implement paging and I don't have a IIIF compliant search service. My stopgap was to use some static test data - I hand modified some of your search results, splitting it up into separate parts and adding paging properties. Without any paging in the only thing that should be tested is that all other behaviours are the same as before.
- A new bower dependency has been introduced and integrated into the search widget for paging through search results.
- I had to do some rearranging of code in _searchWithinResults.js_. Some of the workflow was modified to accommodate the paging widget, since it needed to perform a search directly from a URL without refreshing the entire results widget (which would have redrawn the pager).
- Small change to `searchTab.js` - remove the _box_ parameter, as it seems to be removed in latest IIIF Search spec.
